### PR TITLE
Fixed typo in Keywords

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
     <span class="pair"><span class="key">"description"</span>: <span class="value">"This is a very cool package!"</span>,</span>
     <span class="pair"><span class="key">"version"</span>: "0.3.0",</span>
     <span class="pair"><span class="key">"type"</span>: <span class="value">"library"</span></span>,
-    <span class="pair"><span class="key">"keywords"</span>: <span class="value">"logging, cool, awesome"</span></span>,
+    <span class="pair"><span class="key">"keywords"</span>: <span class="value">["logging", "cool", "awesome"]</span></span>,
     <span class="pair"><span class="key">"homepage"</span>: <span class="value">"http://jolicode.com"</span></span>,
     <span class="pair"><span class="key">"time"</span>: <span class="value">"2012-12-21"</span></span>,
     <span class="pair"><span class="key">"license"</span>: <span class="value">"MIT"</span></span>,


### PR DESCRIPTION
Keywords field must be an array or composer.json wouldn't be valid
